### PR TITLE
Changed SCRIPT_ADDRESS version byte from 5 to 22 to comply with other address tools

### DIFF
--- a/src/base58.h
+++ b/src/base58.h
@@ -273,7 +273,7 @@ public:
     enum
     {
         PUBKEY_ADDRESS = 30, // defcoin addresses start with X
-        SCRIPT_ADDRESS = 5,
+        SCRIPT_ADDRESS = 22,
         PUBKEY_ADDRESS_TEST = 111,
         SCRIPT_ADDRESS_TEST = 196,
     };


### PR DESCRIPTION
DEFCOIN P2PKH addresses begin with a D, such as DPuE992x5UmbUj6Hb3783JSQ5a3GAyMHpZ, but P2SH addresses currently begin with a 3, such as 3ChiCWdXotownkore5tyFYuzRydYzrBmkB.

These can be confused with Bitcoin's P2SH addresses which also begin with a 3.

This pull request alters DEFCOIN's P2SH address prefix so that P2SH addresses begin with either 9 or A. This is compliant with existing tools which observe the "P2PKH+8" convention between P2PKH and P2SH prefixes, such as pycoin, Beerwallet, and any other library that can create addresses.

While at first glance this change may seem 'cosmetic only' since transactions do not use the addresses that are displayed within the client (they use the hash160 of the public key which is encoded within addresses), it's actually important because the "Send to" dialog will reject non-conforming addresses. This change ensures the "Send to" dialog doesn't accept Bitcoin P2SH addresses, and only accepts P2SH addresses that were built for DEFCOIN.
